### PR TITLE
feat: Redesign mock-interview page for per-question practice

### DIFF
--- a/app/service/mock-interview/page.tsx
+++ b/app/service/mock-interview/page.tsx
@@ -3,101 +3,97 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { Mic, Play, Clock, Calendar, TrendingUp, Award, BarChart } from "lucide-react";
+import {
+  Mic,
+  Play,
+  Clock,
+  TrendingUp,
+  Award,
+  BarChart,
+  BookOpen,
+  Target,
+  Bookmark,
+  ArrowRight
+} from "lucide-react";
 
 export default async function MockInterviewPage() {
-  // Mock data
+  // TODO: Replace with real data from GraphQL
   const stats = {
-    totalInterviews: 12,
-    avgScore: 87,
-    totalMinutes: 245,
-    improvement: 15,
+    totalPracticed: 24,
+    avgScore: 82,
+    totalMinutes: 156,
+    bookmarkedCount: 8,
   };
 
-  const interviewHistory = [
+  // TODO: Replace with real practice history from interview_answers table
+  const recentPractice = [
     {
-      id: 1,
-      title: "Senior Software Engineer - Technical",
-      date: "Nov 8, 2025",
-      duration: "35 min",
-      score: 92,
-      feedback: "Excellent technical depth. Great communication skills.",
-      status: "Completed",
-    },
-    {
-      id: 2,
-      title: "Product Manager - Behavioral",
-      date: "Nov 6, 2025",
-      duration: "28 min",
+      id: "q1",
+      questionText: "Tell me about a time when you had to deal with a difficult team member.",
+      category: "behavioral",
+      practicedAt: "2 hours ago",
       score: 85,
-      feedback: "Strong leadership examples. Work on quantifying impact.",
-      status: "Completed",
+      attempts: 3,
     },
     {
-      id: 3,
-      title: "System Design Interview",
-      date: "Nov 4, 2025",
-      duration: "45 min",
-      score: 88,
-      feedback: "Good scalability thinking. Consider more edge cases.",
-      status: "Completed",
+      id: "q2",
+      questionText: "How would you design a URL shortening service like bit.ly?",
+      category: "system_design",
+      practicedAt: "Yesterday",
+      score: 78,
+      attempts: 2,
+    },
+    {
+      id: "q3",
+      questionText: "What is the difference between REST and GraphQL?",
+      category: "technical",
+      practicedAt: "2 days ago",
+      score: 92,
+      attempts: 1,
     },
   ];
 
-  const upcomingInterviews = [
-    {
-      id: 1,
-      title: "Full Stack Developer - Coding",
-      scheduledDate: "Nov 10, 2025",
-      time: "2:00 PM",
-    },
-    {
-      id: 2,
-      title: "Leadership & Management",
-      scheduledDate: "Nov 12, 2025",
-      time: "10:00 AM",
-    },
+  const categoryStats = [
+    { name: "Behavioral", icon: "💼", count: 12, practiced: 8, color: "bg-blue-500" },
+    { name: "Technical", icon: "💻", count: 15, practiced: 6, color: "bg-purple-500" },
+    { name: "System Design", icon: "🏗️", count: 8, practiced: 4, color: "bg-orange-500" },
+    { name: "Leadership", icon: "👥", count: 6, practiced: 3, color: "bg-green-500" },
+    { name: "Problem Solving", icon: "🧩", count: 10, practiced: 2, color: "bg-yellow-500" },
+    { name: "Company Specific", icon: "🎯", count: 5, practiced: 1, color: "bg-pink-500" },
   ];
 
-  const interviewTypes = [
-    {
-      name: "Technical Interview",
-      description: "Coding problems and technical discussions",
-      duration: "45-60 min",
-      difficulty: "Medium-Hard",
-      icon: "💻",
-    },
-    {
-      name: "Behavioral Interview",
-      description: "Past experiences and soft skills",
-      duration: "30-45 min",
-      difficulty: "Medium",
-      icon: "💼",
-    },
-    {
-      name: "System Design",
-      description: "Architecture and scalability questions",
-      duration: "45-60 min",
-      difficulty: "Hard",
-      icon: "🏗️",
-    },
-    {
-      name: "Leadership Interview",
-      description: "Management and team leadership",
-      duration: "30-45 min",
-      difficulty: "Medium",
-      icon: "👥",
-    },
-  ];
+  const getCategoryColor = (category: string) => {
+    const colors: Record<string, string> = {
+      behavioral: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
+      technical: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300",
+      system_design: "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300",
+      leadership: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+      problem_solving: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300",
+      company_specific: "bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-300",
+    };
+    return colors[category] || "bg-gray-100 text-gray-800";
+  };
+
+  const getCategoryLabel = (category: string) => {
+    const labels: Record<string, string> = {
+      behavioral: "Behavioral",
+      technical: "Technical",
+      system_design: "System Design",
+      leadership: "Leadership",
+      problem_solving: "Problem Solving",
+      company_specific: "Company Specific",
+    };
+    return labels[category] || category;
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Mock Interviews</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Question Practice</h1>
           <p className="text-gray-600 dark:text-gray-400 mt-2">
-            Practice with AI-powered mock interviews and get real-time feedback
+            Practice individual interview questions and get AI-powered feedback
           </p>
         </div>
 
@@ -105,50 +101,50 @@ export default async function MockInterviewPage() {
         <div className="grid md:grid-cols-4 gap-4 mb-8">
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600 flex items-center gap-2">
-                <Mic className="h-4 w-4" />
-                Total Interviews
+              <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400 flex items-center gap-2">
+                <Target className="h-4 w-4" />
+                Questions Practiced
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{stats.totalInterviews}</div>
-              <p className="text-xs text-green-600 mt-1">+3 this month</p>
+              <div className="text-2xl font-bold">{stats.totalPracticed}</div>
+              <p className="text-xs text-green-600 mt-1">+5 this week</p>
             </CardContent>
           </Card>
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600 flex items-center gap-2">
+              <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400 flex items-center gap-2">
                 <TrendingUp className="h-4 w-4" />
                 Average Score
               </CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">{stats.avgScore}%</div>
-              <p className="text-xs text-green-600 mt-1">+{stats.improvement}% improvement</p>
+              <p className="text-xs text-green-600 mt-1">+8% improvement</p>
             </CardContent>
           </Card>
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600 flex items-center gap-2">
+              <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400 flex items-center gap-2">
                 <Clock className="h-4 w-4" />
                 Practice Time
               </CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">{stats.totalMinutes} min</div>
-              <p className="text-xs text-gray-600 mt-1">Total practice</p>
+              <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">Total practice</p>
             </CardContent>
           </Card>
           <Card>
             <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-gray-600 flex items-center gap-2">
-                <Award className="h-4 w-4" />
-                Success Rate
+              <CardTitle className="text-sm font-medium text-gray-600 dark:text-gray-400 flex items-center gap-2">
+                <Bookmark className="h-4 w-4" />
+                Bookmarked
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">92%</div>
-              <p className="text-xs text-gray-600 mt-1">Interview success</p>
+              <div className="text-2xl font-bold">{stats.bookmarkedCount}</div>
+              <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">Questions saved</p>
             </CardContent>
           </Card>
         </div>
@@ -156,219 +152,218 @@ export default async function MockInterviewPage() {
         <div className="grid lg:grid-cols-3 gap-8">
           {/* Main Content */}
           <div className="lg:col-span-2 space-y-6">
-            {/* Start New Interview */}
+            {/* Start Practice CTA */}
             <Card className="bg-gradient-to-r from-blue-600 to-purple-600 text-white">
               <CardHeader>
-                <CardTitle className="text-white">Ready for Your Next Interview?</CardTitle>
+                <CardTitle className="text-white">Ready to Practice?</CardTitle>
                 <CardDescription className="text-blue-100">
-                  Start a new AI-powered mock interview session
+                  Pick a question and start practicing with AI feedback
                 </CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="flex gap-3">
                 <Button size="lg" variant="secondary" asChild>
-                  <Link href="/service/mock-interview/new">
-                    <Play className="mr-2 h-5 w-5" />
-                    Start New Interview
+                  <Link href="/service/questions">
+                    <BookOpen className="mr-2 h-5 w-5" />
+                    Browse Questions
+                  </Link>
+                </Button>
+                <Button size="lg" variant="outline" className="bg-white/10 border-white/30 hover:bg-white/20 text-white" asChild>
+                  <Link href="/service/questions?filter=bookmarked">
+                    <Bookmark className="mr-2 h-5 w-5" />
+                    Bookmarked
                   </Link>
                 </Button>
               </CardContent>
             </Card>
 
-            {/* Interview Types */}
+            {/* Category Quick Access */}
             <Card>
               <CardHeader>
-                <CardTitle>Interview Types</CardTitle>
-                <CardDescription>Choose the type of interview you want to practice</CardDescription>
+                <CardTitle>Practice by Category</CardTitle>
+                <CardDescription>Jump into questions by category</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="grid md:grid-cols-2 gap-4">
-                  {interviewTypes.map((type) => (
-                    <Card key={type.name} className="hover:shadow-md transition-shadow cursor-pointer">
-                      <CardContent className="pt-6">
-                        <div className="text-3xl mb-3">{type.icon}</div>
-                        <h3 className="font-semibold mb-2">{type.name}</h3>
-                        <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
-                          {type.description}
-                        </p>
-                        <div className="space-y-2 mb-4">
-                          <div className="flex justify-between text-xs">
-                            <span className="text-gray-600">Duration:</span>
-                            <span className="font-medium">{type.duration}</span>
+                <div className="grid md:grid-cols-2 gap-3">
+                  {categoryStats.map((cat) => (
+                    <Link
+                      key={cat.name}
+                      href={`/service/questions?category=${cat.name.toLowerCase().replace(/\s+/g, '_')}`}
+                      className="block"
+                    >
+                      <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
+                        <CardContent className="pt-4 pb-4">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-3">
+                              <span className="text-2xl">{cat.icon}</span>
+                              <div>
+                                <h3 className="font-medium text-sm">{cat.name}</h3>
+                                <p className="text-xs text-gray-500 dark:text-gray-400">
+                                  {cat.practiced}/{cat.count} practiced
+                                </p>
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <div className="w-16">
+                                <Progress value={(cat.practiced / cat.count) * 100} className="h-2" />
+                              </div>
+                              <ArrowRight className="h-4 w-4 text-gray-400" />
+                            </div>
                           </div>
-                          <div className="flex justify-between text-xs">
-                            <span className="text-gray-600">Difficulty:</span>
-                            <Badge variant="secondary" className="text-xs">
-                              {type.difficulty}
-                            </Badge>
-                          </div>
-                        </div>
-                        <Button variant="outline" size="sm" className="w-full" asChild>
-                          <Link href={`/service/mock-interview/new?type=${type.name.toLowerCase().replace(/\s+/g, '-')}`}>
-                            Start {type.name}
-                          </Link>
-                        </Button>
-                      </CardContent>
-                    </Card>
+                        </CardContent>
+                      </Card>
+                    </Link>
                   ))}
                 </div>
               </CardContent>
             </Card>
 
-            {/* Interview History */}
+            {/* Recent Practice */}
             <Card>
               <CardHeader>
-                <CardTitle>Interview History</CardTitle>
-                <CardDescription>Review your past mock interview sessions</CardDescription>
+                <CardTitle>Recent Practice</CardTitle>
+                <CardDescription>Continue where you left off</CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
-                  {interviewHistory.map((interview) => (
-                    <Card key={interview.id} className="hover:shadow-md transition-shadow">
-                      <CardContent className="pt-6">
-                        <div className="flex items-start justify-between mb-3">
-                          <div>
-                            <h3 className="font-semibold mb-1">{interview.title}</h3>
-                            <div className="flex items-center gap-3 text-sm text-gray-600">
-                              <span className="flex items-center gap-1">
-                                <Calendar className="h-3 w-3" />
-                                {interview.date}
+                  {recentPractice.map((practice) => (
+                    <Card key={practice.id} className="hover:shadow-md transition-shadow">
+                      <CardContent className="pt-4 pb-4">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="flex-1 min-w-0">
+                            <p className="font-medium text-sm mb-2 line-clamp-2">
+                              {practice.questionText}
+                            </p>
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <Badge variant="outline" className={getCategoryColor(practice.category)}>
+                                {getCategoryLabel(practice.category)}
+                              </Badge>
+                              <span className="text-xs text-gray-500 dark:text-gray-400">
+                                {practice.practicedAt}
                               </span>
-                              <span className="flex items-center gap-1">
-                                <Clock className="h-3 w-3" />
-                                {interview.duration}
+                              <span className="text-xs text-gray-500 dark:text-gray-400">
+                                • {practice.attempts} {practice.attempts === 1 ? 'attempt' : 'attempts'}
                               </span>
                             </div>
                           </div>
-                          <Badge variant="default">{interview.status}</Badge>
-                        </div>
-
-                        <div className="mb-3">
-                          <div className="flex items-center justify-between mb-2">
-                            <span className="text-sm font-medium">Performance Score</span>
-                            <span className="text-sm font-bold">{interview.score}/100</span>
+                          <div className="flex items-center gap-3">
+                            <div className="text-right">
+                              <div className="text-lg font-bold">{practice.score}</div>
+                              <div className="text-xs text-gray-500">score</div>
+                            </div>
+                            <Button size="sm" variant="outline" asChild>
+                              <Link href={`/service/questions/${practice.id}/practice`}>
+                                <Play className="h-3 w-3 mr-1" />
+                                Retry
+                              </Link>
+                            </Button>
                           </div>
-                          <Progress value={interview.score} />
-                        </div>
-
-                        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3 mb-3">
-                          <p className="text-sm text-gray-700 dark:text-gray-300">
-                            <strong>Feedback:</strong> {interview.feedback}
-                          </p>
-                        </div>
-
-                        <div className="flex gap-2">
-                          <Button size="sm" variant="outline" asChild>
-                            <Link href={`/service/mock-interview/${interview.id}`}>
-                              View Details
-                            </Link>
-                          </Button>
-                          <Button size="sm" variant="outline" asChild>
-                            <Link href={`/service/mock-interview/${interview.id}/recording`}>
-                              <Play className="mr-2 h-3 w-3" />
-                              Watch Recording
-                            </Link>
-                          </Button>
                         </div>
                       </CardContent>
                     </Card>
                   ))}
                 </div>
+                {recentPractice.length > 0 && (
+                  <Button variant="ghost" className="w-full mt-4" asChild>
+                    <Link href="/service/questions?sort=recent">
+                      View All Practice History
+                      <ArrowRight className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                )}
               </CardContent>
             </Card>
           </div>
 
           {/* Sidebar */}
           <div className="space-y-6">
-            {/* Upcoming Sessions */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Calendar className="h-5 w-5" />
-                  Upcoming Sessions
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {upcomingInterviews.map((interview) => (
-                  <div key={interview.id} className="border-l-2 border-blue-600 pl-4">
-                    <p className="font-medium text-sm mb-1">{interview.title}</p>
-                    <p className="text-xs text-gray-600 mb-2">
-                      {interview.scheduledDate} at {interview.time}
-                    </p>
-                    <Button size="sm" variant="outline" className="w-full">
-                      Join Session
-                    </Button>
-                  </div>
-                ))}
-                <Button variant="outline" className="w-full" size="sm" asChild>
-                  <Link href="/service/mock-interview/schedule">
-                    Schedule New Session
-                  </Link>
-                </Button>
-              </CardContent>
-            </Card>
-
-            {/* Performance Insights */}
+            {/* Quick Stats */}
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
                   <BarChart className="h-5 w-5" />
-                  Performance Insights
+                  Performance by Category
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div>
                   <div className="flex justify-between text-sm mb-2">
-                    <span>Communication</span>
-                    <span className="font-medium">90%</span>
-                  </div>
-                  <Progress value={90} />
-                </div>
-                <div>
-                  <div className="flex justify-between text-sm mb-2">
-                    <span>Technical Knowledge</span>
-                    <span className="font-medium">85%</span>
-                  </div>
-                  <Progress value={85} />
-                </div>
-                <div>
-                  <div className="flex justify-between text-sm mb-2">
-                    <span>Problem Solving</span>
+                    <span>Behavioral</span>
                     <span className="font-medium">88%</span>
                   </div>
                   <Progress value={88} />
                 </div>
                 <div>
                   <div className="flex justify-between text-sm mb-2">
-                    <span>Confidence</span>
+                    <span>Technical</span>
+                    <span className="font-medium">76%</span>
+                  </div>
+                  <Progress value={76} />
+                </div>
+                <div>
+                  <div className="flex justify-between text-sm mb-2">
+                    <span>System Design</span>
                     <span className="font-medium">82%</span>
                   </div>
                   <Progress value={82} />
                 </div>
+                <div>
+                  <div className="flex justify-between text-sm mb-2">
+                    <span>Leadership</span>
+                    <span className="font-medium">90%</span>
+                  </div>
+                  <Progress value={90} />
+                </div>
+                <div>
+                  <div className="flex justify-between text-sm mb-2">
+                    <span>Problem Solving</span>
+                    <span className="font-medium">72%</span>
+                  </div>
+                  <Progress value={72} />
+                </div>
               </CardContent>
             </Card>
 
-            {/* Tips */}
+            {/* Practice Tips */}
             <Card>
               <CardHeader>
-                <CardTitle>Interview Tips</CardTitle>
+                <CardTitle className="flex items-center gap-2">
+                  <Award className="h-5 w-5" />
+                  Practice Tips
+                </CardTitle>
               </CardHeader>
               <CardContent className="space-y-3 text-sm">
                 <div className="flex items-start gap-2">
-                  <div className="font-medium">1.</div>
-                  <p>Find a quiet space with good lighting</p>
+                  <Mic className="h-4 w-4 mt-0.5 text-blue-500" />
+                  <p>Practice answering out loud for better retention</p>
                 </div>
                 <div className="flex items-start gap-2">
-                  <div className="font-medium">2.</div>
-                  <p>Test your microphone before starting</p>
+                  <Clock className="h-4 w-4 mt-0.5 text-blue-500" />
+                  <p>Aim for 2-3 minute responses for behavioral questions</p>
                 </div>
                 <div className="flex items-start gap-2">
-                  <div className="font-medium">3.</div>
-                  <p>Speak clearly and maintain eye contact</p>
+                  <Target className="h-4 w-4 mt-0.5 text-blue-500" />
+                  <p>Use the STAR method: Situation, Task, Action, Result</p>
                 </div>
                 <div className="flex items-start gap-2">
-                  <div className="font-medium">4.</div>
-                  <p>Take your time to think before answering</p>
+                  <BookOpen className="h-4 w-4 mt-0.5 text-blue-500" />
+                  <p>Review suggested answers after each practice</p>
                 </div>
+              </CardContent>
+            </Card>
+
+            {/* Generate More Questions */}
+            <Card className="border-dashed">
+              <CardContent className="pt-6 text-center">
+                <div className="text-4xl mb-3">📝</div>
+                <h3 className="font-semibold mb-2">Need More Questions?</h3>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                  Generate new questions from your resume
+                </p>
+                <Button variant="outline" className="w-full" asChild>
+                  <Link href="/service/questions">
+                    Generate Questions
+                  </Link>
+                </Button>
               </CardContent>
             </Card>
           </div>
@@ -377,4 +372,3 @@ export default async function MockInterviewPage() {
     </div>
   );
 }
-


### PR DESCRIPTION
- Change from full interview sessions (40-50min) to individual question practice
- Update header: "Mock Interviews" → "Question Practice"
- Replace interview type cards with category-based quick access
- Remove scheduled interviews section
- Add recent practice history with retry functionality
- Update stats to focus on questions practiced and bookmarks
- Add practice tips for STAR method and best practices